### PR TITLE
chore: improve CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,19 @@
 version: 2
 jobs:
-  build-linux-default:
+  build-arduino-default:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Make scripts executable 
+          command: sudo chmod -R +x ./.circleci/*.sh
+      - run:
+          name: Install
+          command: ./.circleci/install_arduino.sh
+      - run:
+          name: Build
+          command: ./.circleci/script_arduino.sh
+  build-platformio-default:
     machine: true
     steps:
       - checkout
@@ -58,42 +71,43 @@ jobs:
       - run:
           name: Build
           command: ./.circleci/script_desktop.sh
-  build-macos-9-2:
-    macos:
-      xcode: "9.2.0"
-    steps:
-      - checkout
-      - run: COMPILER=clang++
-      - run:
-          name: Install dependencies
-          command: brew install cmake lcov
-      - run:
-          name: Make scripts executable 
-          command: sudo chmod -R +x ./.circleci/*.sh
-      - run:
-          name: Build
-          command: ./.circleci/script_desktop.sh
-  build-macos-9-3:
-    macos:
-      xcode: "9.3.0"
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: brew install cmake lcov
-      - run:
-          name: Make scripts executable 
-          command: sudo chmod -R +x ./.circleci/*.sh
-      - run:
-          name: Build
-          command: ./.circleci/script_desktop.sh
+  # build-macos-9-2:
+  #   macos:
+  #     xcode: "9.2.0"
+  #   steps:
+  #     - checkout
+  #     - run: COMPILER=clang++
+  #     - run:
+  #         name: Install dependencies
+  #         command: brew install cmake lcov
+  #     - run:
+  #         name: Make scripts executable 
+  #         command: sudo chmod -R +x ./.circleci/*.sh
+  #     - run:
+  #         name: Build
+  #         command: ./.circleci/script_desktop.sh
+  # build-macos-9-3:
+  #   macos:
+  #     xcode: "9.3.0"
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Install dependencies
+  #         command: brew install cmake lcov
+  #     - run:
+  #         name: Make scripts executable 
+  #         command: sudo chmod -R +x ./.circleci/*.sh
+  #     - run:
+  #         name: Build
+  #         command: ./.circleci/script_desktop.sh
 
 workflows:
   version: 2
   build:
     jobs:
-      - build-linux-default
+      - build-arduino-esp32-default
+      - build-platformio-default
       - build-linux-gcc7
       - build-linux-clang-5
-      - build-macos-9-2
-      - build-macos-9-3
+      # - build-macos-9-2
+      # - build-macos-9-3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-arduino-esp32-default
+      - build-arduino-default
       - build-platformio-default
       - build-linux-gcc7
       - build-linux-clang-5

--- a/.circleci/install_arduino.sh
+++ b/.circleci/install_arduino.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+sudo apt-get install bzip2
+yes | sudo apt install python-pip
+pip install pyserial
+pip install --upgrade pip
+
+wget -O arduino-cli-linux64.tar.bz2 https://github.com/arduino/arduino-cli/releases/download/0.3.3-alpha.preview/arduino-cli-0.3.3-alpha.preview-linux64.tar.bz2
+bunzip2 arduino-cli-linux64.tar.bz2
+tar xvf arduino-cli-linux64.tar
+
+sudo mv arduino-cli-0.3.3-alpha.preview-linux64 /usr/local/share/arduino-cli
+sudo ln -s /usr/local/share/arduino-cli /usr/local/bin/arduino-cli
+
+printf "board_manager:
+  additional_urls:
+    - https://dl.espressif.com/dl/package_esp32_index.json" >> .cli-config.yml
+sudo mv .cli-config.yml /usr/local/share/
+
+arduino-cli core update-index
+arduino-cli core install esp32:esp32

--- a/.circleci/script_arduino.sh
+++ b/.circleci/script_arduino.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+mkdir -p ~/Arduino/libraries/BIP66/
+mv ~/project/* ~/Arduino/libraries/BIP66
+
+arduino-cli compile --output temp.bin -b esp32:esp32:esp32 $PWD/examples/BIP66/BIP66.ino --debug

--- a/.circleci/script_arduino.sh
+++ b/.circleci/script_arduino.sh
@@ -3,4 +3,4 @@
 mkdir -p ~/Arduino/libraries/BIP66/
 mv ~/project/* ~/Arduino/libraries/BIP66
 
-arduino-cli compile --output temp.bin -b esp32:esp32:esp32 $PWD/examples/BIP66/BIP66.ino --debug
+arduino-cli compile --output temp.bin -b esp32:esp32:esp32 ~/Arduino/libraries/BIP66/examples/BIP66/BIP66.ino --debug


### PR DESCRIPTION
add arduino esp32 build, renamed linux-default to platformio-default.

Commented-out paid macOS builds.