### PR TITLE
release: v.0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ on:
     types: [opened, edited, ready_for_review]
 
 jobs:
+
   arduino-build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
       - name: Install Arduino IDE & ESP32 Package
@@ -38,7 +38,6 @@ jobs:
 
   platformio-build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
       - name: Install Platformio
@@ -52,7 +51,6 @@ jobs:
 
   linux-gcc7:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
       - name: Install Dependencies
@@ -62,18 +60,14 @@ jobs:
             sudo apt-get -y install g++-7 cmake
       - name: CMake
         run: |
-          mkdir build
-          cd build
-          cmake -DBUILD_BIP66_TESTS=ON ..
+          mkdir build && cd build
+          cmake -DUNIT_TEST=ON ..
           cmake --build .
       - name: Run Tests
-        run: |
-          cd build
-          ./test/bip66_tests
+        run: ./build/test/bip66_tests
 
   linux-clang-5:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
       - name: Install Dependencies
@@ -82,18 +76,14 @@ jobs:
           sudo apt-get -y install clang-5.0 clang-format-5.0 cmake
       - name: CMake
         run: |
-          mkdir build
-          cd build
-          cmake -DBUILD_BIP66_TESTS=ON ..
+          mkdir build && cd build
+          cmake -DUNIT_TEST=ON ..
           cmake --build .
       - name: Run tests
-        run: |
-          cd build
-          ./test/bip66_tests
+        run: ./build/test/bip66_tests
 
   macos:
     runs-on: macOS-latest
-
     steps:
       - uses: actions/checkout@v1
       - run: COMPILER=clang++
@@ -101,14 +91,11 @@ jobs:
         run: brew install cmake
       - name: CMake
         run: |
-          mkdir build
-          cd build
-          cmake -DBUILD_BIP66_TESTS=ON ..
+          mkdir build && cd build
+          cmake -DUNIT_TEST=ON ..
           cmake --build .
       - name: Run Tests
-        run: |
-          cd build
-          ./test/bip66_tests
+        run: ./build/test/bip66_tests
 
   windows:
     runs-on: windows-2016
@@ -116,16 +103,13 @@ jobs:
       fail-fast: false
       matrix:
         build: [Debug, Release]
-
     steps:
       - uses: actions/checkout@v1
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
-      - name: Install
-        run: git submodule update --init --recursive
       - name: CMake
-        run: cmake -G "Visual Studio 15 2017 Win64" -DBUILD_BIP66_TESTS=ON .
+        run: cmake -DUNIT_TEST=ON -G "Visual Studio 15 2017 Win64" .
       - name: Build Solution
-        run: msbuild "%GITHUB_WORKSPACE%\BIP66.sln"
+        run: msbuild "%GITHUB_WORKSPACE%\bip66.sln"
       - name: Run Tests
         run: call "%GITHUB_WORKSPACE%\test\Debug\bip66_tests"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "extern/googletest"]
-	path = extern/googletest
-	url = https://github.com/google/googletest.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [0.3.0] - 2019-XX-XX
+## [v0.3.1] - 2019-10-08
 
 ### Changed
 
--   improved overall implementation (_see release for changes_). -->
+-   improved overall implementation ([v0.3.1])
 
 ## [0.2.1] - 2019-05-20
 
@@ -40,4 +40,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.1.0]: https://github.com/sleepdefic1t/bip66/releases/tag/0.1.0
 [0.2.0]: https://github.com/sleepdefic1t/bip66/compare/0.1.0...0.2.0
 [0.2.1]: https://github.com/sleepdefic1t/bip66/compare/0.2.0...0.2.1
-<!-- [0.3.0]: https://github.com/sleepdefic1t/bip66/compare/0.2.0...0.3.0 -->
+[v0.3.1]: https://github.com/sleepdefic1t/bip66/compare/0.2.0...v0.3.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,28 @@
 
 cmake_minimum_required(VERSION 3.2)
 
-project(BIP66)
+project(bip66)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR})
+set(EXTERNAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/extern)
 
 if (MSVC)
-	add_definitions(
-		-D_CRT_SECURE_NO_WARNINGS
-		-D_SCL_SECURE_NO_WARNINGS
-		-DNOMINMAX
-	)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8")
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS
+                    -D_SCL_SECURE_NO_WARNINGS
+                    -DNOMINMAX)
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
 endif()
 
 add_subdirectory(src)
 
-option(BUILD_BIP66_TESTS "BIP66 tests disabled by default" OFF)
-if(BUILD_BIP66_TESTS)
-	add_subdirectory(test)
+option(UNIT_TEST "BIP66 tests disabled by default" OFF)
+
+if(UNIT_TEST)
+    add_subdirectory(test)
 endif()

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) Simon Downey <simon@ark.io> <https://github.com/sleepdefic1t>
+Copyright (c) Ark Ecosystem <info@ark.io>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This build should be done out of source.
 2) `cmake ..`
 3) `cmake --build .`
 
-**Building and Running Tests**
+**Building and Run Tests**
 
 1) `mkdir build && cd build`
 2) `cmake -DUNIT_TEST=ON ..`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BIP66
 
 <p align="center">
-    <img src="https://github.com/sleepdefic1t/BIP66/raw/master/bip66_logo.png" width="320 " height="320"/>
+    <img src="https://github.com/sleepdefic1t/BIP66/raw/master/bip66_logo.png" width=50% height=auto/>
 </p>
 
 > A simple Bitcoin BIP66 Implementation in C++ for the ARK Ecosystem.
@@ -85,7 +85,7 @@ This build should be done out of source.
 #### Building the running Tests
 
 1) `mkdir build && cd build`
-2) `cmake -DBUILD_BIP66_TESTS=ON ..`
+2) `cmake -DUNIT_TEST=ON ..`
 3) `cmake --build .`
 4) `./test/bip66_tests`
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ ANS.1 DER Encoder/Decoder based on [Bitcoin BIP66](https://github.com/bitcoin/bi
 
 ### Arduino IDE
 
+Download BIP66 from the Arduino IDE Library manager, or clone/download this repo and place it in the Arduino Libraries directory.  (_e.g. `~Documents/Arduino/libraries`_)
+
 1) Open the `BIP66.ino` sketch in the `examples/BIP66` folder.  
 2) Select your board from the Arduino IDE
 3) Upload the sketch.
@@ -57,32 +59,28 @@ ANS.1 DER Encoder/Decoder based on [Bitcoin BIP66](https://github.com/bitcoin/bi
 
 ### PlatformIO
 
-#### Building the Library
+**Building the Library**
+-    `pio run`
 
-- `pio run`
+**Building the Library with Tests**
+-    `pio run -t test/`
 
-#### Building the Library with Tests
-
-- `pio run -t test/`
-
-#### Uploading and Running Tests
-
-- `pio run -t test/ -e esp32 -t upload`
+**Uploading and Running Tests**
+-    `pio run -t test/ -e esp32 -t upload`
 
 ---
 
-### OS Builds
+### CMake
 
 Operating System builds like Linux, macOS, and Windows use CMake to build this BIP66 library.  
 This build should be done out of source.
 
-#### Building the Library
-
+**Building the Library**
 1) `mkdir build && cd build`
 2) `cmake ..`
 3) `cmake --build .`
 
-#### Building the running Tests
+**Building and Running Tests**
 
 1) `mkdir build && cd build`
 2) `cmake -DUNIT_TEST=ON ..`

--- a/cmake/GTest.cmake
+++ b/cmake/GTest.cmake
@@ -1,0 +1,35 @@
+
+# ------------------------------------------------------------------------------
+# Google Test
+# ------------------------------------------------------------------------------
+
+option(BUILD_GMOCK OFF FORCE)
+option(PACKAGE_TESTS OFF FORCE)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+configure_file(${CMAKE_SOURCE_DIR}/cmake/GTest.txt.in
+               ${EXTERNAL_LIBRARY_DIR}/googletest/CMakeLists.txt)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY ${EXTERNAL_LIBRARY_DIR}/googletest )
+
+if(result)
+    message(FATAL_ERROR "GTEST: CMake Failed: ${result}")
+endif()
+
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY ${EXTERNAL_LIBRARY_DIR}/googletest )
+
+if(result)
+    message(FATAL_ERROR "GTest: Build Failed: ${result}")
+endif()
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+add_subdirectory("${EXTERNAL_LIBRARY_DIR}/googletest/src"
+                 "${EXTERNAL_LIBRARY_DIR}/googletest/build"
+                 EXCLUDE_FROM_ALL)
+
+# ------------------------------------------------------------------------------

--- a/cmake/GTest.txt.in
+++ b/cmake/GTest.txt.in
@@ -1,0 +1,21 @@
+
+cmake_minimum_required(VERSION 3.2)
+
+include(ExternalProject)
+
+# ------------------------------------------------------------------------------
+# Google Test
+# ------------------------------------------------------------------------------
+
+ExternalProject_Add(GoogleTest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           v1.10.x
+  SOURCE_DIR        "${EXTERNAL_LIBRARY_DIR}/googletest/src"
+  BINARY_DIR        "${EXTERNAL_LIBRARY_DIR}/googletest/build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)
+
+# ------------------------------------------------------------------------------

--- a/library.json
+++ b/library.json
@@ -7,12 +7,17 @@
     "type": "git",
     "url": "https://github.com/sleepdefic1t/bip66.git"
   },
-  "version": "0.3.0",
+  "version": "0.3.1",
   "authors": [
     {
       "name": "Ark Ecosystem",
       "email": "info@ark.io",
       "url": "https://github.com/ArkEcosystem"
+    },
+    {
+      "name": "Simon Downey",
+      "email": "simon@ark.io",
+      "url": "https://github.com/sleepdefic1t"
     }
   ],
   "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=BIP66
-version=0.3.0
+version=0.3.1
 author=Ark Ecosystem
-maintainer=Ark Ecosystem
+maintainer=Simon Downey
 sentence=A simple Bitcoin BIP66 Implementation in C++ for the ARK Ecosystem.
 paragraph=DER Encoding and Decoding of ECDSA secp256k1 Signatures.
 category=Communication

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,16 @@
 
 cmake_minimum_required(VERSION 3.2)
 
-project(BIP66 CXX)
+project(bip66 C CXX)
+
+# ------------------------------------------------------------------------------
 
 add_library(${PROJECT_NAME} SHARED STATIC bip66.cpp)
 
-set(BIP66_BUILD_INCLUDE_DIRS
-    ${PROJECT_SOURCE_DIR}
-)
+set(BIP66_BUILD_INCLUDE_DIRS ${PROJECT_SOURCE_DIR})
+
 include_directories(${BIP66_BUILD_INCLUDE_DIRS})
 
-target_include_directories(${PROJECT_NAME} PUBLIC
-    ${BIP66_BUILD_INCLUDE_DIRS}
-)
+target_include_directories(${PROJECT_NAME} PUBLIC ${BIP66_BUILD_INCLUDE_DIRS})
+
+# ------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,28 +1,24 @@
 
 cmake_minimum_required(VERSION 3.2)
 
-project(bip66_tests C CXX)
+project(${PROJECT_NAME}_tests C CXX)
 
 # ------------------------------------------------------------------------------
 # Google Test
 # ------------------------------------------------------------------------------
 
-# clone submodules
-execute_process(
-	COMMAND git submodule update --init --recursive
-	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-option(BUILD_GMOCK OFF FORCE)
-option(PACKAGE_TESTS OFF FORCE)
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-add_subdirectory(../extern/googletest [EXCLUDE_FROM_ALL])
+include(${CMAKE_SOURCE_DIR}/cmake/GTest.cmake)
 
 # ------------------------------------------------------------------------------
 
-find_library(BIP66 PUBLIC)
+# ------------------------------------------------------------------------------
+# Link BIP66 to the Test Libraries
+# ------------------------------------------------------------------------------
+
+find_library(bip66 PUBLIC)
 
 add_executable(${PROJECT_NAME} bip66.cpp)
 
-target_link_libraries(${PROJECT_NAME} BIP66 gtest gtest_main)
+target_link_libraries(${PROJECT_NAME} bip66 gtest gtest_main)
+
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
# v.0.3.1

**Changes since [v0.2.1](https://github.com/sleepdefic1t/BIP66/releases/tag/0.2.1)**
- drops vectors for arrays (bye bye dynamic allocation).
- reworks logic to lower complexity.
- improves project layout.
- moves builds fully out of source.
- moves Google Test out of source and drops the submodule method.
- updates test vectors to be const c arrays.

## Installation

### Arduino IDE

Download BIP66 from the Arduino IDE Library manager, or clone/download this repo and place it in the Arduino Libraries directory.  (_e.g. `~Documents/Arduino/libraries`_)
1) Open the `BIP66.ino` sketch in the `examples/BIP66` folder.  
2) Select your board from the Arduino IDE
3) Upload the sketch.

### PlatformIO

**Building the Library**
-    `pio run`

**Building the Library with Tests**
-    `pio run -t test/`

**Uploading and Running Tests**
-    `pio run -t test/ -e esp32 -t upload`

### CMake

Operating System builds like Linux, macOS, and Windows use CMake to build this BIP66 library.  
This build should be done out of source.

**Building the Library**
1) `mkdir build && cd build`
2) `cmake ..`
3) `cmake --build .`

**Building and Run Tests**
1) `mkdir build && cd build`
2) `cmake -DUNIT_TEST=ON ..`
3) `cmake --build .`
4) `./test/bip66_tests`