### PR TITLE
release: 0.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         run: ./build/test/bip66_tests
 
   windows:
-    runs-on: windows-2016
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
@@ -108,8 +108,10 @@ jobs:
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
       - name: CMake
-        run: cmake -DUNIT_TEST=ON -G "Visual Studio 15 2017 Win64" .
+        run: cmake -DUNIT_TEST=ON -G "Visual Studio 16 2019" -A x64 .
       - name: Build Solution
+        shell: cmd
         run: msbuild "%GITHUB_WORKSPACE%\bip66.sln"
       - name: Run Tests
+        shell: cmd
         run: call "%GITHUB_WORKSPACE%\test\Debug\bip66_tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.2][] - 2019-11-27
+
+### Changed
+
+- improvements to reduce code reuse and improve accuracy ([0.3.2][])
+
 ## [v0.3.1][] - 2019-10-08
 
 ### Changed
@@ -41,3 +47,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.2.0]: https://github.com/sleepdefic1t/bip66/compare/0.1.0...0.2.0
 [0.2.1]: https://github.com/sleepdefic1t/bip66/compare/0.2.0...0.2.1
 [v0.3.1]: https://github.com/sleepdefic1t/bip66/compare/0.2.0...v0.3.1
+[0.3.2]: https://github.com/sleepdefic1t/bip66/compare/0.2.0...0.3.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.2)
 
 project(bip66)
 
+# ------------------------------------------------------------------------------
+# Set the Environment Variables
+# ------------------------------------------------------------------------------
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 11)
 
@@ -19,10 +23,28 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
 endif()
 
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Add the BIP66 Library Subdirectory
+# ------------------------------------------------------------------------------
+
 add_subdirectory(src)
+
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Add the BIP66 Test Subdirectory
+#
+# Disabled by default.
+#
+# Use `cmake -DUNIT_TEST=ON .` to enable Test building.
+# ------------------------------------------------------------------------------
 
 option(UNIT_TEST "BIP66 tests disabled by default" OFF)
 
 if(UNIT_TEST)
     add_subdirectory(test)
 endif()
+
+# ------------------------------------------------------------------------------

--- a/cmake/GTest.txt.in
+++ b/cmake/GTest.txt.in
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.2)
 
+project(googletest-download)
+
 include(ExternalProject)
 
 # ------------------------------------------------------------------------------
@@ -10,6 +12,7 @@ include(ExternalProject)
 ExternalProject_Add(GoogleTest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           v1.10.x
+  GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${EXTERNAL_LIBRARY_DIR}/googletest/src"
   BINARY_DIR        "${EXTERNAL_LIBRARY_DIR}/googletest/build"
   CONFIGURE_COMMAND ""

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,9 +12,9 @@ bip66	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-check	KEYWORD2
-decode	KEYWORD2
 encode	KEYWORD2
+decode	KEYWORD2
+check	KEYWORD2
 
 ######################################
 # Constants (LITERAL1)

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/sleepdefic1t/bip66.git"
   },
-  "version": "0.3.1",
+  "version": "0.3.2",
   "authors": [
     {
       "name": "Ark Ecosystem",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=BIP66
-version=0.3.1
+version=0.3.2
 author=Ark Ecosystem
 maintainer=Simon Downey
 sentence=A simple Bitcoin BIP66 Implementation in C++ for the ARK Ecosystem.

--- a/src/bip66.hpp
+++ b/src/bip66.hpp
@@ -31,28 +31,24 @@
 
 #include <cstdint>
 
-////////////////////////////////////////////////////////////////////////////////
-
 namespace bip66 {
 
 ////////////////////////////////////////////////////////////////////////////////
-
 bool encode(const uint8_t *rElement,
-            const uint8_t rElementLength,
+            const uint8_t &rElementLength,
             const uint8_t *sElement,
-            const uint8_t sElementLength,
+            const uint8_t &sElementLength,
             uint8_t *outSignature);
 
+////////////////////////////////////////////////////////////////////////////////
 bool decode(const uint8_t *signature,
-            const uint8_t signatureLength,
+            const uint8_t &signatureLength,
             uint8_t *outR,
             uint8_t *outS);
 
-bool check(const uint8_t *signature, uint8_t signatureLength);
-
 ////////////////////////////////////////////////////////////////////////////////
+bool check(const uint8_t *signature, const uint8_t &signatureLength);
 
 }  // namespace bip66
 
 #endif
-

--- a/test/bip66.cpp
+++ b/test/bip66.cpp
@@ -28,15 +28,14 @@
 
 #include "gtest/gtest.h"
 
+#include <bip66.hpp>
+
 #include <array>
 #include <cstdint>
-
-#include <bip66.hpp>
 
 #include "test_cases.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST(BIP66, encode) {
     const uint8_t count     = ENC_DEC_COUNT;
     uint8_t matches         = 0U;
@@ -54,7 +53,6 @@ TEST(BIP66, encode) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST(BIP66, encode_valid) {
     const uint8_t count     = VALID_ENCODED_COUNT;
     uint8_t matches         = 0U;
@@ -72,7 +70,6 @@ TEST(BIP66, encode_valid) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST(BIP66, encode_invalid) {
     const uint8_t count     = INVALID_RS_COUNT;
     uint8_t misses          = 0U;
@@ -90,7 +87,6 @@ TEST(BIP66, encode_invalid) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST(BIP66, decode) {
     uint8_t matches = 0U;
 
@@ -120,7 +116,6 @@ TEST(BIP66, decode_valid) {
     ASSERT_EQ(matches, count);
 }
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST(BIP66, decode_invalid) {
     const uint8_t count     = VALID_ENCODED_COUNT;
     uint8_t misses          = 0U;
@@ -137,7 +132,6 @@ TEST(BIP66, decode_invalid) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST(BIP66, check) {
     uint8_t matches = 0U;
 
@@ -147,7 +141,6 @@ TEST(BIP66, check) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST(BIP66, check_valid) {
     const uint8_t count     = VALID_ENCODED_COUNT;
     uint8_t matches         = 0U;
@@ -160,7 +153,6 @@ TEST(BIP66, check_valid) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST(BIP66, check_invalid) {
     const uint8_t count     = INVALID_ENCODED_COUNT;
     uint8_t misses          = 0U;
@@ -171,5 +163,3 @@ TEST(BIP66, check_invalid) {
 
     ASSERT_EQ(misses, count);
 }
-
-////////////////////////////////////////////////////////////////////////////////

--- a/test/test_cases.hpp
+++ b/test/test_cases.hpp
@@ -30,30 +30,36 @@
 #define BIP66_TEST_CASES_H
 
 #include <cstdint>
+#include <cstddef>
 
 ////////////////////////////////////////////////////////////////////////////////
+// Global Constants
+constexpr size_t ELEMENT_LENGTH            = 32U;
 
-#define ELEMENT_LENGTH              32U
+constexpr size_t ENC_DEC_COUNT             = 5U;
+constexpr size_t DECODED_LENGTH            = 64U;
+constexpr size_t ENCODED_LENGTH            = 70U;
+constexpr size_t ENCODED_MAX_LENGTH        = 72U;
 
-#define ENC_DEC_COUNT               5U
-#define DECODED_LENGTH              64U
-#define ENCODED_LENGTH              70U
-#define ENCODED_MAX_LENGTH          72U
+constexpr size_t VALID_ENCODED_COUNT       = 9U;
+constexpr size_t VALID_ENCODED_LENGTH      = 71U;
+constexpr size_t VALID_R_LENGTH            = 33U;
+constexpr size_t VALID_S_LENGTH            = 34U;
 
-#define VALID_ENCODED_COUNT         9U
-#define VALID_ENCODED_LENGTH        71U
-#define VALID_R_LENGTH              33U
-#define VALID_S_LENGTH              34U
-
-#define INVALID_ENCODED_COUNT       15U
-#define INVALID_ENCODED_LENGTH      74U
-#define INVALID_RS_COUNT            8U
-#define INVALID_RS_LENGTH           35U
+constexpr size_t INVALID_ENCODED_COUNT     = 15U;
+constexpr size_t INVALID_ENCODED_LENGTH    = 74U;
+constexpr size_t INVALID_RS_COUNT          = 8U;
+constexpr size_t INVALID_RS_LENGTH         = 35U;
 
 ////////////////////////////////////////////////////////////////////////////////
+// Test cases adapted from:
+// https://github.com/bitcoinjs/bip66/blob/master/test/fixtures.json
+//
+// ---
+namespace test_cases {  // NOLINT
 
-namespace test_cases {
-constexpr const uint8_t encoded[ENC_DEC_COUNT][ENCODED_LENGTH] = {
+////////////////////////////////////////////////////////////////////////////////
+constexpr uint8_t encoded[ENC_DEC_COUNT][ENCODED_LENGTH] = {
         // 3044022021704f2adb2e4a10a3ddc1d7d64552b8061c05f6d12a168c69091c75581d611402200edf37689d2786fc690af9f0f6fa1f629c95695039f648a6d455484302402e93
     { 48, 68, 2, 32, 33, 112, 79, 42, 219, 46, 74, 16, 163, 221, 193, 215, 214, 69, 82, 184, 6, 28, 5, 246, 209, 42, 22, 140, 105, 9, 28, 117, 88, 29, 97, 20, 2, 32, 14, 223, 55, 104, 157, 39, 134, 252, 105, 10, 249, 240, 246, 250, 31, 98, 156, 149, 105, 80, 57, 246, 72, 166, 212, 85, 72, 67, 2, 64, 46, 147 },
         // 3044022038044de976712d32fbf37451c266e1867e6e31b4e69ada8792a94db32078ab5802204c146804cc62f2231d39d9e3afc704b51e491cee0c7cfa6ac3548f3db4c511da
@@ -66,7 +72,8 @@ constexpr const uint8_t encoded[ENC_DEC_COUNT][ENCODED_LENGTH] = {
     { 48, 68, 2, 32, 0, 148, 233, 61, 184, 240, 196, 17, 127, 179, 45, 44, 83, 75, 39, 112, 207, 61, 108, 205, 198, 76, 124, 218, 52, 32, 129, 175, 166, 148, 125, 63, 2, 32, 84, 34, 23, 111, 170, 225, 35, 3, 56, 159, 243, 81, 231, 6, 65, 23, 122, 27, 67, 134, 250, 231, 97, 63, 47, 74, 53, 55, 221, 96, 26, 80 }
 };  // encoded
 
-constexpr const uint8_t decoded[ENC_DEC_COUNT][DECODED_LENGTH] = {
+////////////////////////////////////////////////////////////////////////////////
+constexpr uint8_t decoded[ENC_DEC_COUNT][DECODED_LENGTH] = {
         // 21704f2adb2e4a10a3ddc1d7d64552b8061c05f6d12a168c69091c75581d61140edf37689d2786fc690af9f0f6fa1f629c95695039f648a6d455484302402e93
     { 33, 112, 79, 42, 219, 46, 74, 16, 163, 221, 193, 215, 214, 69, 82, 184, 6, 28, 5, 246, 209, 42, 22, 140, 105, 9, 28, 117, 88, 29, 97, 20, 14, 223, 55, 104, 157, 39, 134, 252, 105, 10, 249, 240, 246, 250, 31, 98, 156, 149, 105, 80, 57, 246, 72, 166, 212, 85, 72, 67, 2, 64, 46, 147 },
         // 38044de976712d32fbf37451c266e1867e6e31b4e69ada8792a94db32078ab584c146804cc62f2231d39d9e3afc704b51e491cee0c7cfa6ac3548f3db4c511da
@@ -80,10 +87,11 @@ constexpr const uint8_t decoded[ENC_DEC_COUNT][DECODED_LENGTH] = {
 };  // decoded
 
 ////////////////////////////////////////////////////////////////////////////////
-
-// additional test cases adapted from: https://github.com/bitcoinjs/bip66/blob/master/test/fixtures.json
+// Valid Cases
 namespace valid {
-constexpr const uint8_t encoded[VALID_ENCODED_COUNT][VALID_ENCODED_LENGTH] = {
+
+////////////////////////////////////////////////////////////////////////////////
+constexpr uint8_t encoded[VALID_ENCODED_COUNT][VALID_ENCODED_LENGTH] = {
         // len[0] + 3044022029db2d5f4e1dcc04e19266cce3cb135865784c62ab653b307f0e0bb744f5c2aa022000a97f5826912cac8b44d9f577a26f169a2f8db781f2ddb7de2bc886e93b6844
     { 70, 48, 68, 2, 32, 41, 219, 45, 95, 78, 29, 204, 4, 225, 146, 102, 204, 227, 203, 19, 88, 101, 120, 76, 98, 171, 101, 59, 48, 127, 14, 11, 183, 68, 245, 194, 170, 2, 32, 0, 169, 127, 88, 38, 145, 44, 172, 139, 68, 217, 245, 119, 162, 111, 22, 154, 47, 141, 183, 129, 242, 221, 183, 222, 43, 200, 134, 233, 59, 104, 68 },
         // len[0] + 304302201ea1fdff81b3a271659df4aad19bc4ef83def389131a36358fe64b245632e777021f29e164658be9ce810921bf81d6b86694785a79ea1e52dbfa5105148d1f0bc1
@@ -104,7 +112,8 @@ constexpr const uint8_t encoded[VALID_ENCODED_COUNT][VALID_ENCODED_LENGTH] = {
     { 8, 48, 6, 2, 1, 0, 2, 1, 0 }
 };  //  encoded
 
-constexpr const uint8_t r[VALID_ENCODED_COUNT][VALID_R_LENGTH] = {
+////////////////////////////////////////////////////////////////////////////////
+constexpr uint8_t r[VALID_ENCODED_COUNT][VALID_R_LENGTH] = {
         // len[0] + 29db2d5f4e1dcc04e19266cce3cb135865784c62ab653b307f0e0bb744f5c2aa
     { 32, 41, 219, 45, 95, 78, 29, 204, 4, 225, 146, 102, 204, 227, 203, 19, 88, 101, 120, 76, 98, 171, 101, 59, 48, 127, 14, 11, 183, 68, 245, 194, 170 },
         // len[0] + 1ea1fdff81b3a271659df4aad19bc4ef83def389131a36358fe64b245632e777
@@ -125,7 +134,8 @@ constexpr const uint8_t r[VALID_ENCODED_COUNT][VALID_R_LENGTH] = {
     { 1, 0 }
 };  // r
 
-constexpr const uint8_t s[VALID_ENCODED_COUNT][VALID_S_LENGTH] = {
+////////////////////////////////////////////////////////////////////////////////
+constexpr uint8_t s[VALID_ENCODED_COUNT][VALID_S_LENGTH] = {
         // len[0] + 00a97f5826912cac8b44d9f577a26f169a2f8db781f2ddb7de2bc886e93b6844
     { 32, 0, 169, 127, 88, 38, 145, 44, 172, 139, 68, 217, 245, 119, 162, 111, 22, 154, 47, 141, 183, 129, 242, 221, 183, 222, 43, 200, 134, 233, 59, 104, 68 },
         // len[0] + 29e164658be9ce810921bf81d6b86694785a79ea1e52dbfa5105148d1f0bc1
@@ -145,12 +155,15 @@ constexpr const uint8_t s[VALID_ENCODED_COUNT][VALID_S_LENGTH] = {
         // len[0] + 0
     { 1, 0 }
 };  // s
+
 }  // namespace valid
 
 ////////////////////////////////////////////////////////////////////////////////
-
+// Invalid Cases
 namespace invalid {
-constexpr const uint8_t encoded[INVALID_ENCODED_COUNT][INVALID_ENCODED_LENGTH] = {
+
+////////////////////////////////////////////////////////////////////////////////
+constexpr uint8_t encoded[INVALID_ENCODED_COUNT][INVALID_ENCODED_LENGTH] = {
         // DER sequence length is too short
         // len[0] + ffffffffffffff
     { 7, 255, 255, 255, 255, 255, 255, 255 },
@@ -198,7 +211,8 @@ constexpr const uint8_t encoded[INVALID_ENCODED_COUNT][INVALID_ENCODED_LENGTH] =
     { 14, 48, 12, 2, 4, 0, 255, 255, 255, 2, 4, 0, 0, 255, 255 }
 };  // der
 
-constexpr const uint8_t r[INVALID_RS_COUNT][INVALID_RS_LENGTH] = {
+////////////////////////////////////////////////////////////////////////////////
+constexpr uint8_t r[INVALID_RS_COUNT][INVALID_RS_LENGTH] = {
         // R length is zero
         // len[0] + r: ""
     { 0 },
@@ -221,7 +235,8 @@ constexpr const uint8_t r[INVALID_RS_COUNT][INVALID_RS_LENGTH] = {
     { 33, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
 };  // r
 
-constexpr const uint8_t  s[INVALID_RS_COUNT][INVALID_RS_LENGTH] = {
+////////////////////////////////////////////////////////////////////////////////
+constexpr uint8_t  s[INVALID_RS_COUNT][INVALID_RS_LENGTH] = {
         //  s: 0080000000000000000000000000000000000000000000000000000000000000
     { 32, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
         // s length is zero
@@ -243,9 +258,8 @@ constexpr const uint8_t  s[INVALID_RS_COUNT][INVALID_RS_LENGTH] = {
         // len[0] + s: 00800000000000000000000000000000000000000000000000000000000000000000
     { 34, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 }; // s
+
 }  // namespace invalid
 }  // namespace test_cases
-
-////////////////////////////////////////////////////////////////////////////////
 
 #endif


### PR DESCRIPTION
- ci(gh actions): use `windows-latest`.
- ci(gh actions): use ""Visual Studio 16 2019" -A x64".
- ci(gh actions): add shell `cmd` use.
- cmake: resolve project(ProjectName) warning.
- cmake: resolve 'detached HEAD' state warning.
- use constexpr vs #define for global variables.
- refactor methods to reduce code reuse and improve accuracy.
- misc. formatting and whitespace improvements.
- update `Keywords.txt`.
- v0.3.1 -> 0.3.2.
- docs: update changelog
